### PR TITLE
Top items by revenue

### DIFF
--- a/app/controllers/api/v1/items/items_by_revenue_controller.rb
+++ b/app/controllers/api/v1/items/items_by_revenue_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::Items::ItemsByRevenueController < ApplicationController
+
+  def index
+    render json: Item.top_items_by_total_revenue(params["quantity"].to_i), each_serializer: ItemSerializer
+  end
+
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,4 +8,12 @@ class Item < ApplicationRecord
     order('RANDOM()').first
   end
 
+  def self.top_items_by_total_revenue(quantity)
+    select("items.*, SUM(invoice_items.quantity * invoice_items.unit_price) AS revenue")
+      .joins(invoice_items: [invoice: [:transactions]])
+      .merge(Transaction.successful)
+      .group(:id)
+      .order("revenue DESC")
+      .limit(quantity)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
         get '/find', to: "search#show"
         get '/find_all', to: "search#index"
         get '/random', to: "random#show"
+        get '/most_revenue', to: "items_by_revenue#index"
       end
 
       resources :items, only: [:index, :show]

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,4 +15,34 @@ RSpec.describe Item, type: :model do
     it {should have_many(:invoices).through(:invoice_items)}
   end
 
+  describe "Class methods" do
+    describe "#top_items_by_total_revenue" do
+      it "returns top x items by total revenue" do
+        customer = create(:customer)
+        merchant = create(:merchant)
+        invoice_1 = create(:invoice, customer: customer, merchant: merchant)
+        invoice_2 = create(:invoice, customer: customer, merchant: merchant)
+        invoice_3 = create(:invoice, customer: customer, merchant: merchant)
+        transaction_1 = create(:transaction, invoice: invoice_1)
+        transaction_2 = create(:transaction, invoice: invoice_2)
+        transaction_3 = create(:transaction, invoice: invoice_3, result: "failed")
+
+        top_item = create(:item, merchant: merchant)
+        middle_item = create(:item, merchant: merchant)
+        bottom_item = create(:item, merchant: merchant)
+
+        create(:invoice_item, invoice: invoice_1,
+               quantity: 5, unit_price: 2, item: top_item)
+        create(:invoice_item, invoice: invoice_2,
+               quantity: 4, unit_price: 2, item: middle_item)
+        create(:invoice_item, invoice: invoice_3,
+               quantity: 6, unit_price: 2, item: bottom_item)
+
+        expect(Item.top_items_by_total_revenue(2).to_a.count).to eq(2)
+        expect(Item.top_items_by_total_revenue(2).first).to eq(top_item)
+        expect(Item.top_items_by_total_revenue(2).last).to eq(middle_item)
+        expect(Item.top_items_by_total_revenue(1).last).to eq(top_item)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/business_intelligence/top_items_by_revenue_request_spec.rb
+++ b/spec/requests/api/v1/business_intelligence/top_items_by_revenue_request_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe "Top items by total revenue Finder API" do
+  it "returns top x items by total revenue" do
+    get "/api/v1/items/most_revenue?quantity=2"
+
+    items = JSON.parse(response.body)
+
+    customer = create(:customer)
+    merchant = create(:merchant)
+    invoice_1 = create(:invoice, customer: customer, merchant: merchant)
+    invoice_2 = create(:invoice, customer: customer, merchant: merchant)
+    invoice_3 = create(:invoice, customer: customer, merchant: merchant)
+    transaction_1 = create(:transaction, invoice: invoice_1)
+    transaction_2 = create(:transaction, invoice: invoice_2)
+    transaction_3 = create(:transaction, invoice: invoice_3, result: "failed")
+
+    top_item = create(:item, merchant: merchant)
+    middle_item = create(:item, merchant: merchant)
+    bottom_item = create(:item, merchant: merchant)
+
+    create(:invoice_item, invoice: invoice_1,
+           quantity: 5, unit_price: 2, item: top_item)
+    create(:invoice_item, invoice: invoice_2,
+           quantity: 4, unit_price: 2, item: middle_item)
+    create(:invoice_item, invoice: invoice_3,
+           quantity: 6, unit_price: 2, item: bottom_item)
+
+    expect(items.count).to eq(2)
+    expect(items.first["id"]).to eq(1)
+    expect(items.last["id"]).to eq(2)
+  end
+end

--- a/spec/requests/api/v1/business_intelligence/top_items_by_revenue_request_spec.rb
+++ b/spec/requests/api/v1/business_intelligence/top_items_by_revenue_request_spec.rb
@@ -1,11 +1,7 @@
 require 'rails_helper'
 
 describe "Top items by total revenue Finder API" do
-  it "returns top x items by total revenue" do
-    get "/api/v1/items/most_revenue?quantity=2"
-
-    items = JSON.parse(response.body)
-
+  before(:each) do
     customer = create(:customer)
     merchant = create(:merchant)
     invoice_1 = create(:invoice, customer: customer, merchant: merchant)
@@ -25,6 +21,12 @@ describe "Top items by total revenue Finder API" do
            quantity: 4, unit_price: 2, item: middle_item)
     create(:invoice_item, invoice: invoice_3,
            quantity: 6, unit_price: 2, item: bottom_item)
+  end
+
+  it "returns top x items by total revenue" do
+    get "/api/v1/items/most_revenue?quantity=2"
+
+    items = JSON.parse(response.body)
 
     expect(items.count).to eq(2)
     expect(items.first["id"]).to eq(1)


### PR DESCRIPTION
Changes Made:
+ add class method #top_items_by_total_revenue to item model and spec
+ write top_items_by_total_revenue_request_spec
+ create items by revenue controller namespaced under items controller

Related Issue(s):

Reviewers:
@AtmaVichara 